### PR TITLE
Add --model opus to Claude Action workflow

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -309,6 +309,7 @@ jobs:
             For any other non-zero exit, surface the stderr so the human
             can fix the configuration.
           claude_args: >-
+            --model opus
             --allowedTools "Read,Grep,Glob,Edit,Write,Skill,Task,Agent,Bash(*),WebFetch,WebSearch"
             --disallowedTools
             "Bash(rm -rf /),Bash(git push --force*),Bash(git push -*f*),Bash(git


### PR DESCRIPTION
Adds `--model opus` to `claude_args` in `.github/workflows/claude.yaml` so the Claude GitHub Action runs the latest Opus model instead of the default (Sonnet).

Rollout of chriscalo/dev-skills#549 (the `opus` alias, not a pinned version).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxPxjPqz8n9Q1M4upwCuNr)_